### PR TITLE
Class page work

### DIFF
--- a/cli/src/Page.ts
+++ b/cli/src/Page.ts
@@ -11,6 +11,8 @@ export class Page {
     if (!/^\//.test(path)) {
       throw new Error(`expected Page path '${path}' to begin with slash (/)`);
     }
+    // Replace invalid symbols
+    path = path.replace(/[<>]/g, "_");
     if (!isValidPath(path)) {
       throw new Error(`invalid Page path: ${path}`);
     }

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -92,7 +92,13 @@ async function processClassDoc(
 ): Promise<void> {
   const root = md.root([
     md.heading(1, md.text(doc.asString)),
+
+    // Class hierarchy
+    ...makeSuperclassList(doc),
+
+    // Comment body
     tagsToMdast(project, doc.inlineTags),
+
     md.heading(2, md.text("Constructors")),
     md.list(
       "unordered",
@@ -175,4 +181,16 @@ function makeTable(labels: string[], rows: (Node | Node[])[][]) {
       }),
     ]
   );
+}
+
+function makeSuperclassList(doc: ParsedClassDoc) {
+  const { superclassType } = doc;
+  if (superclassType == null) {
+    return [];
+  }
+
+  return [
+    md.paragraph(md.emphasis(md.text("Superclass:"))),
+    md.list("unordered", [md.listItem(md.text(superclassType.asString))]),
+  ];
 }

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -94,7 +94,10 @@ async function processClassDoc(
     md.heading(1, md.text(doc.asString)),
 
     // Class hierarchy
-    ...makeSuperclassList(doc),
+    ...makeSuperclassList(project, doc),
+
+    // Implemented interfaces
+    ...makeImplementedInterfacesList(project, doc),
 
     // Comment body
     tagsToMdast(project, doc.inlineTags),
@@ -183,14 +186,41 @@ function makeTable(labels: string[], rows: (Node | Node[])[][]) {
   );
 }
 
-function makeSuperclassList(doc: ParsedClassDoc) {
+function makeSuperclassList(project: Project, doc: ParsedClassDoc) {
   const { superclassType } = doc;
   if (superclassType == null) {
     return [];
   }
 
+  const { qualifiedTypeName } = superclassType;
   return [
     md.paragraph(md.emphasis(md.text("Superclass:"))),
-    md.list("unordered", [md.listItem(md.text(superclassType.asString))]),
+    md.list("unordered", [
+      md.listItem(
+        project.makeInternalLink(qualifiedTypeName, qualifiedTypeName, [
+          md.text(qualifiedTypeName),
+        ])
+      ),
+    ]),
+  ];
+}
+
+function makeImplementedInterfacesList(project: Project, doc: ParsedClassDoc) {
+  const { interfaceTypes } = doc;
+  if (interfaceTypes.length === 0) {
+    return [];
+  }
+  return [
+    md.paragraph(md.emphasis(md.text("Implemented interfaces:"))),
+    md.list(
+      "unordered",
+      interfaceTypes.map(({ qualifiedTypeName }) =>
+        md.listItem(
+          project.makeInternalLink(qualifiedTypeName, qualifiedTypeName, [
+            md.text(qualifiedTypeName),
+          ])
+        )
+      )
+    ),
   ];
 }

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -292,7 +292,24 @@ function makeClassDocPageBody(args: MakeSectionArgs): Node[] {
       project,
       doc,
       depth,
+      title: "Field Detail",
+      shouldMakeSection: () => doc.fields.length !== 0,
+      makeBody: () =>
+        doc.fields
+          .map((doc) => [
+            project.makeAnchor(`${doc.name}${doc.name.replace(/\s/g, "")}`),
+            md.heading(3, md.text(doc.name)),
+            tagsToMdast(project, doc.inlineTags),
+          ])
+          .flat(1),
+    }),
+
+    ...makeSection({
+      project,
+      doc,
+      depth,
       title: "Method Detail",
+      shouldMakeSection: () => doc.methods.length !== 0,
       makeBody: () =>
         doc.methods
           .map((doc) => [

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -265,7 +265,11 @@ function makeClassDocPageBody(args: MakeSectionArgs): Node[] {
         makeTable(
           ["Modifier and Type", "Method and Description"],
           doc.methods.map((doc) => [
-            [md.text(doc.modifiers), md.text(doc.returnType.typeName)],
+            [
+              md.text(doc.modifiers),
+              md.text(" "),
+              md.text(doc.returnType.typeName),
+            ],
             [
               md.paragraph(
                 project.makeInternalLink(`#${doc.name}`, `#${doc.name}`, [

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -267,12 +267,21 @@ function makeClassDocPageBody(args: MakeSectionArgs): Node[] {
           doc.methods.map((doc) => [
             [md.text(doc.modifiers), md.text(doc.returnType.typeName)],
             [
-              md.paragraph([
-                md.text(doc.name),
-                ...doc.parameters.map((parameter) =>
-                  md.text(parameter.asString)
-                ),
-              ]),
+              md.paragraph(
+                project.makeInternalLink(`#${doc.name}`, `#${doc.name}`, [
+                  md.text(doc.name),
+                  md.text("("),
+                  ...doc.parameters
+                    .map((parameter, i) => [
+                      md.text(parameter.asString),
+                      i === doc.parameters.length - 1
+                        ? md.text("")
+                        : md.text(", "),
+                    ])
+                    .flat(1),
+                  md.text(")\n\n"),
+                ])
+              ),
               md.paragraph(tagsToMdast(project, doc.firstSentenceTags)),
             ],
           ])

--- a/plugins/JsonDocletJava8/src/main/kotlin/com/yokedox/Docs.kt
+++ b/plugins/JsonDocletJava8/src/main/kotlin/com/yokedox/Docs.kt
@@ -18,6 +18,7 @@ fun parse(v: ClassDoc): JsonValue {
         "serializableFields" to v.serializableFields().map { toJson(it) },
         "definesSerializableFields" to v.definesSerializableFields(),
         "superclassType" to toJson(v.superclassType()),
+        // "interfaces" not included because "interfaceTypes" is recommended instead
         "interfaceTypes" to v.interfaceTypes().map { toJson(it) },
         "typeParameters" to v.typeParameters().map { toJson(it) },
         "typeParamTags" to v.typeParamTags().map { toJson(it) },

--- a/plugins/JsonDocletJava8/src/main/kotlin/com/yokedox/Types.kt
+++ b/plugins/JsonDocletJava8/src/main/kotlin/com/yokedox/Types.kt
@@ -9,9 +9,15 @@ fun toJson(v: Type?): JsonObject? {
     if (v == null) {
         return null
     }
+
     val value = mutableMapOf(
         "_class" to "Type",
-        "asString" to v.toString(),
+        "asString" to try {
+            v.toString()
+        } catch (e: NullPointerException) {
+            // This might fail on some types for some reason.
+            "${v.qualifiedTypeName()} (toString() failed)"
+        },
         "typeName" to v.typeName(),
         "qualifiedTypeName" to v.qualifiedTypeName(),
         "simpleTypeName" to v.simpleTypeName(),


### PR DESCRIPTION
Fixes the following:
- Top of page should include class hierarchy
- Note "all implemented interfaces" with links
- Do not include empty sections (e.g. "constructors" section when the class has no constructors)
- Links from summary sections to details sections
- Field details
- Spaces between modifier and return type in method summary
