### PR TITLE
Add debugGeneratorResultPath option

### DIFF
--- a/cli/src/Plugin.ts
+++ b/cli/src/Plugin.ts
@@ -41,4 +41,10 @@ export type PluginArgs<UserDataType = unknown> = {
     modify these arguments as needed.
    */
   generatorArgs: (string | number)[];
+
+  /**
+    If set, plugins should bypass the generator step and treat the given path as
+    containing the result of a generator call.
+   */
+  debugGeneratorResultPath?: string;
 };

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -26,15 +26,27 @@ export const cli = yargs
           alias: "o",
           string: true,
           describe: "output path",
+        })
+        .option("outputMdastJson", {
+          boolean: true,
+          describe: "whether to output mdast json files",
+        })
+        .option("outputRst", {
+          boolean: true,
+          describe: "whether to output rST files",
+        })
+        .option("debugGeneratorResultPath", {
+          string: true,
+          describe:
+            "bypass the generator step and treat the given path as the result of a generator call",
         });
     },
     (args) => {
       assert(args.generator !== undefined);
       run({
-        generator: args.generator,
-        plugin: args.plugin,
+        ...args,
+        generator: args.generator, // strict null check
         generatorArgs: args._.slice(1),
-        out: args.out,
       });
     }
   )

--- a/cli/src/makeProject.ts
+++ b/cli/src/makeProject.ts
@@ -14,6 +14,33 @@ import {
 import { Project } from "./Project.js";
 import { LinkToEntityNode, md } from "./yokedast.js";
 
+export type MakeProjectArgs = {
+  /**
+    Output path.
+   */
+  out?: string;
+
+  /**
+    The file system library. Can be swapped for unit testing.
+   */
+  fs?: typeof promises;
+
+  /**
+    Whether to output mdast json files.
+   */
+  outputMdastJson?: boolean;
+
+  /**
+    Whether to output markdown files.
+   */
+  outputMarkdown?: boolean;
+
+  /**
+    Whether to output rST files.
+   */
+  outputRst?: boolean;
+};
+
 /**
   Creates a project object, which is a collection of documentation pages.
  */
@@ -23,13 +50,7 @@ export async function makeProject({
   outputMdastJson = true,
   outputMarkdown = false,
   outputRst = true,
-}: {
-  out?: string;
-  fs?: typeof promises;
-  outputMdastJson?: boolean;
-  outputMarkdown?: boolean;
-  outputRst?: boolean;
-}): Promise<Project> {
+}: MakeProjectArgs): Promise<Project> {
   // Use the current working directy if no output directory was provided
   const outputDirectoryPath = Path.resolve(out ?? "");
 

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -19,8 +19,10 @@ export type JavadocEntityData = {
 
 const Javadoc: Plugin<JavadocEntityData> = {
   async run(args): Promise<void> {
-    // 1. Run javadoc with JSON doclet to produce JSON files in temporary directory
-    const { jsonPath } = await execJavadoc(args);
+    // 1. Run javadoc with JSON doclet to produce JSON files in temporary
+    //    directory OR consume existing files at debugGeneratorResultPath
+    const jsonPath =
+      args.debugGeneratorResultPath ?? (await execJavadoc(args)).jsonPath;
     // 2. Consume JSON files and produce Yokedox entities
     await processJson({ ...args, jsonPath });
     // 3. Build indexes and additional pages

--- a/cli/src/run.ts
+++ b/cli/src/run.ts
@@ -1,38 +1,24 @@
 import tmp from "tmp-promise";
 import { loadPlugin } from "./loadPlugin.js";
-import { makeProject } from "./makeProject.js";
-
+import { makeProject, MakeProjectArgs } from "./makeProject.js";
+import { PluginArgs } from "./Plugin.js";
 /**
   Arguments passed to the run command.
  */
-export interface RunArgs {
-  /**
-    Name of or path to generator executable.
-   */
-  generator: string;
-
-  /**
-    Arguments after end-of-options flag (--) to be passed to the generator.
-   */
-  generatorArgs: (string | number)[];
-
-  /**
+export type RunArgs = Omit<PluginArgs, "tempDir" | "project"> &
+  MakeProjectArgs & {
+    /**
     Path to plugin.
    */
-  plugin?: string;
-
-  /**
-    Output path.
-   */
-  out?: string;
-}
+    plugin?: string;
+  };
 
 /**
   Runs a given generator in the current working directory.
  */
 export const run = async (args: RunArgs): Promise<void> => {
   // Validate and open output location, set up output functions
-  const project = await makeProject({ ...args });
+  const project = await makeProject(args);
 
   // Load the plugin
   const plugin = await loadPlugin(args);
@@ -46,9 +32,8 @@ export const run = async (args: RunArgs): Promise<void> => {
   try {
     // Delegate to plugin
     await plugin.run({
+      ...args,
       project,
-      generator: args.generator,
-      generatorArgs: args.generatorArgs,
       tempDir: tempDir.path,
     });
   } finally {


### PR DESCRIPTION
- This allows devs to bypass the actual generator step (e.g. 'javadoc') and
consume the existing result of a previous generator run.
- This is NOT first class (i.e. this is marked debug-) and I didn't separate the
Plugin interface because plugins are written with a self-cleaning temp directory
and it would make it harder to reason about the cleanup if the plugin run function
were split up.
- If it proves to be useful we can make it first class later.
- Also: clean up some args types.