### PR TITLE
(DOCSP-18294): Support external entities

### DIFF
--- a/cli/src/Entity.ts
+++ b/cli/src/Entity.ts
@@ -1,11 +1,34 @@
-/**
-  An entity is anything that can be documented and linked to.
- */
-export type Entity<UserDataType = unknown> = {
+export type InternalEntity<UserDataType = unknown> = {
   /**
     The complete, unique name of the entity.
    */
   canonicalName: string;
+
+  /**
+    The location of the entity.
+   */
   pageUri: string;
+
+  /**
+    Custom data.
+   */
   data?: UserDataType;
 };
+
+/**
+  An entity is anything that can be documented and linked to.
+ */
+export type Entity<UserDataType = unknown> = InternalEntity<UserDataType> & {
+  /**
+    Whether this entity exists outside of the site.
+   */
+  isExternal: boolean;
+};
+
+export type ExternalEntity<UserDataType = unknown> = Entity<UserDataType> & {
+  isExternal: true;
+};
+
+export type ExternalEntityTransformer<UserDataType = unknown> = (
+  canonicalName: string
+) => ExternalEntity<UserDataType> | undefined;

--- a/cli/src/Project.ts
+++ b/cli/src/Project.ts
@@ -1,4 +1,4 @@
-import { Entity } from "./Entity.js";
+import { Entity, ExternalEntityTransformer, InternalEntity } from "./Entity.js";
 import { Page } from "./Page.js";
 import { EntityAnchorNode, LinkToEntityNode } from "./yokedast.js";
 
@@ -14,7 +14,15 @@ export type Project<UserDataType = unknown> = {
     types in mdast. Using this method ensures consistency and enables link
     validation. Anchors made without this function may not be validated.
    */
-  declareEntity(entity: Entity<UserDataType>): EntityAnchorNode;
+  declareEntity(entity: InternalEntity<UserDataType>): EntityAnchorNode;
+
+  /**
+    Adds the given external entity transformer to the project's list of external
+    entity transformers. This takes a 
+   */
+  addExternalEntityTransformer(
+    transform: ExternalEntityTransformer<UserDataType>
+  ): void;
 
   /**
     Create a link to a specific entity.

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -19,6 +19,20 @@ export type JavadocEntityData = {
 
 const Javadoc: Plugin<JavadocEntityData> = {
   async run(args): Promise<void> {
+    const { project } = args;
+    // Handle external entities
+    project.addExternalEntityTransformer((canonicalName) => {
+      if (!/^java\./.test(canonicalName)) {
+        return undefined;
+      }
+      const path = canonicalName.split(".").join("/");
+      return {
+        isExternal: true,
+        canonicalName,
+        pageUri: `https://docs.oracle.com/javase/7/docs/api/${path}.html`,
+      };
+    });
+
     // 1. Run javadoc with JSON doclet to produce JSON files in temporary
     //    directory OR consume existing files at debugGeneratorResultPath
     const jsonPath =

--- a/cli/src/yokedast.ts
+++ b/cli/src/yokedast.ts
@@ -21,6 +21,7 @@ export type LinkToEntityNode = Parent & {
   linkText: string;
   url?: string;
   title?: string;
+  isExternal?: boolean;
 };
 
 /**


### PR DESCRIPTION
In action: (note java.lang links now working) https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/test3/io.realm.annotations.PrimaryKey/
