### PR TITLE
(DOCSP-18291): Organize classes into packages of docs sections

### DIFF
--- a/cli/src/plugins/javadoc/buildIndexes.ts
+++ b/cli/src/plugins/javadoc/buildIndexes.ts
@@ -18,7 +18,7 @@ export const buildIndexes = async ({
   const root = md.root([
     toctree(
       finalizedProject.entities
-        .filter((e) => e.data?.category === "class")
+        .filter((e) => e.data?.category === "package")
         .map((entity) => {
           const linkToEntity = finalizedProject.linkToEntity(
             entity.canonicalName
@@ -28,8 +28,8 @@ export const buildIndexes = async ({
           }
           const link = linkToEntity as TypedNode<"link">;
           return toctreeItem({
-            url: link.url.replace(/#.*$/, ""),
-            value: entity.canonicalName,
+            url: link.url.replace(/#.*$/, "").replace(/\./g,'/'),
+            value: entity.canonicalName.replace(/#.*$/, "").replace('/', ''),
           });
         })
         .filter((e) => e !== undefined) as ToctreeItemNode[]
@@ -38,5 +38,26 @@ export const buildIndexes = async ({
   finalizedProject.writePage({
     path: "/index",
     root,
+  });
+
+  const packages = finalizedProject.entities
+    .filter((e) => e.data?.category === "package")
+
+  packages.forEach(pkg => {
+    const pkgRoot = md.root([
+      toctree(finalizedProject.entities.filter((e) => e.data?.category === "class").filter((e) => e.data?.containingPackage === pkg.canonicalName)
+        .map(child => {
+          const sanitizedName = child.canonicalName.replace(/#.*$/, "");
+          const value = sanitizedName.substring(sanitizedName.lastIndexOf('.') + 1) // only want simple class name
+          return toctreeItem({
+            url: child.canonicalName.replace(/\./g,'/'),
+            value
+          })
+        }).filter((e) => e !== undefined) as ToctreeItemNode[])
+    ])
+    finalizedProject.writePage({
+      path: pkg.canonicalName.replace(/\./g,'/'),
+      root: pkgRoot
+    })
   });
 };


### PR DESCRIPTION
Still a WIP, PRing for some comments and suggestions before I double down on this approach and clean things up/check in the tests.

Staging link for preview: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/package-reorg/io/realm/Realm/