### PR TITLE
(DOCSP-18290): Fix longform entity description links

### DIFF
--- a/cli/src/plugins/javadoc/tagsToYokedast.ts
+++ b/cli/src/plugins/javadoc/tagsToYokedast.ts
@@ -112,7 +112,7 @@ const visitor: TagVisitor<Project, Node | Node[]> = {
   SeeTag(tag, project) {
     return project.linkToEntity(
       [tag.referencedClassName, tag.referencedMemberName]
-        .filter((e) => e !== null)
+        .filter((e) => e != null)
         .join("."),
       tag.text
     );


### PR DESCRIPTION
See https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/test4/io/realm/DynamicRealm/#public-static-dynamicrealm-getinstance--realmconfiguration-configuration-

Previously: "Realm instance defined by provided ..." would have been a broken link.

Not sure what's going on with the unformatted :ref:s below. Will investigate.
