### PR TITLE
(DOCSP-18299): Support non-linking entities (built-ins) for javadoc

### DIFF
--- a/cli/src/Entity.ts
+++ b/cli/src/Entity.ts
@@ -15,20 +15,18 @@ export type InternalEntity<UserDataType = unknown> = {
   data?: UserDataType;
 };
 
+export type EntityType = "internal" | "external" | "builtIn";
+
 /**
   An entity is anything that can be documented and linked to.
  */
 export type Entity<UserDataType = unknown> = InternalEntity<UserDataType> & {
   /**
-    Whether this entity exists outside of the site.
+    The entity type.
    */
-  isExternal: boolean;
+  type: EntityType;
 };
 
-export type ExternalEntity<UserDataType = unknown> = Entity<UserDataType> & {
-  isExternal: true;
-};
-
-export type ExternalEntityTransformer<UserDataType = unknown> = (
+export type EntityTransformer<UserDataType = unknown> = (
   canonicalName: string
-) => ExternalEntity<UserDataType> | undefined;
+) => Entity<UserDataType> | undefined;

--- a/cli/src/Project.ts
+++ b/cli/src/Project.ts
@@ -1,4 +1,4 @@
-import { Entity, ExternalEntityTransformer, InternalEntity } from "./Entity.js";
+import { Entity, EntityTransformer, InternalEntity } from "./Entity.js";
 import { Page } from "./Page.js";
 import { EntityAnchorNode, LinkToEntityNode } from "./yokedast.js";
 
@@ -17,12 +17,14 @@ export type Project<UserDataType = unknown> = {
   declareEntity(entity: InternalEntity<UserDataType>): EntityAnchorNode;
 
   /**
-    Adds the given external entity transformer to the project's list of external
-    entity transformers. This takes a 
+    Adds the given entity transformer to the project's list of entity
+    transformers.
+
+    This is used to handle entities that are not declared within the actual
+    project -- e.g. built-ins (int, void) or externals (standard library
+    entities).
    */
-  addExternalEntityTransformer(
-    transform: ExternalEntityTransformer<UserDataType>
-  ): void;
+  addEntityTransformer(transform: EntityTransformer<UserDataType>): void;
 
   /**
     Create a link to a specific entity.

--- a/cli/src/makeProject.test.ts
+++ b/cli/src/makeProject.test.ts
@@ -53,7 +53,7 @@ describe("makeProject", () => {
     );
 
     await expect(fs.readFile("/index.json", "utf8")).resolves.toBe(
-      '{"path":"/index","root":{"type":"root","children":[{"type":"html","value":"<a name=\\"index\\" ></a>","anchorName":"index","entity":{"canonicalName":"index","pageUri":"/index","isExternal":false}},{"type":"heading","children":[{"type":"text","value":"heading"}],"depth":1}]}}'
+      '{"path":"/index","root":{"type":"root","children":[{"type":"html","value":"<a name=\\"index\\" ></a>","anchorName":"index","entity":{"canonicalName":"index","pageUri":"/index","type":"internal"}},{"type":"heading","children":[{"type":"text","value":"heading"}],"depth":1}]}}'
     );
 
     await project.writePage(
@@ -61,7 +61,7 @@ describe("makeProject", () => {
     );
 
     await expect(fs.readFile("/file2.json", "utf8")).resolves.toBe(
-      '{"path":"/file2","root":{"type":"root","children":[{"type":"link","children":[{"type":"text","value":"index"}],"url":"/index#index","title":"index","linkText":"index","targetCanonicalName":"index","isPending":false,"isExternal":false}]}}'
+      '{"path":"/file2","root":{"type":"root","children":[{"type":"link","children":[{"type":"text","value":"index"}],"url":"/index#index","title":"index","linkText":"index","targetCanonicalName":"index","entityType":"internal","isPending":false}]}}'
     );
   });
 
@@ -107,7 +107,7 @@ describe("makeProject", () => {
     );
 
     await expect(fs.readFile("/foo.json", "utf8")).resolves.toBe(
-      '{"path":"/foo","root":{"type":"root","children":[{"type":"html","value":"<a name=\\"bar\\" ></a>","anchorName":"bar","entity":{"canonicalName":"bar","pageUri":"/foo","isExternal":false}}]}}'
+      '{"path":"/foo","root":{"type":"root","children":[{"type":"html","value":"<a name=\\"bar\\" ></a>","anchorName":"bar","entity":{"canonicalName":"bar","pageUri":"/foo","type":"internal"}}]}}'
     );
 
     // Finalize flushes remaining pages
@@ -115,7 +115,7 @@ describe("makeProject", () => {
 
     // Finalized with resolved links
     await expect(fs.readFile("/index.json", "utf8")).resolves.toBe(
-      '{"path":"/index","root":{"type":"root","children":[{"type":"link","children":[{"type":"text","value":"bar"}],"targetCanonicalName":"bar","isPending":false,"linkText":"bar","url":"/foo#bar","title":"bar","isExternal":false}]}}'
+      '{"path":"/index","root":{"type":"root","children":[{"type":"link","children":[{"type":"text","value":"bar"}],"targetCanonicalName":"bar","isPending":false,"linkText":"bar","url":"/foo#bar","title":"bar","entityType":"internal"}]}}'
     );
   });
 
@@ -176,10 +176,10 @@ describe("makeProject", () => {
   it("supports external entities", async () => {
     const fs = makeJsonFs();
     const project = await makeProject({ out: "/", fs });
-    project.addExternalEntityTransformer((canonicalName) => {
+    project.addEntityTransformer((canonicalName) => {
       return /^ext\./.test(canonicalName)
         ? {
-            isExternal: true,
+            type: "external",
             pageUri: `https://example.com/${canonicalName}`,
             canonicalName,
           }
@@ -197,7 +197,7 @@ describe("makeProject", () => {
     await project.finalize();
 
     await expect(fs.readFile("/index.json", "utf8")).resolves.toBe(
-      '{"path":"/index","root":{"type":"root","children":[{"type":"link","children":[{"type":"text","value":"ext.something"}],"targetCanonicalName":"ext.something","isPending":false,"linkText":"ext.something","url":"https://example.com/ext.something","title":"ext.something","isExternal":true},{"type":"strong","children":[{"type":"text","value":"int.something"},{"type":"text","value":" (?)"}],"targetCanonicalName":"int.something","isPending":true,"linkText":"int.something"}]}}'
+      '{"path":"/index","root":{"type":"root","children":[{"type":"link","children":[{"type":"text","value":"ext.something"}],"targetCanonicalName":"ext.something","isPending":false,"linkText":"ext.something","url":"https://example.com/ext.something","title":"ext.something","entityType":"external"},{"type":"strong","children":[{"type":"text","value":"int.something"},{"type":"text","value":" (?)"}],"targetCanonicalName":"int.something","isPending":true,"linkText":"int.something"}]}}'
     );
   });
 });


### PR DESCRIPTION
Demo: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/test4

Click around and note void, int, etc. are now bold and not "broken links" (marked with a question mark).
