### PR TITLE
General cleanup, object type in title

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9487,9 +9487,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -42,7 +42,7 @@
     "jest": "^27.0.5",
     "json-schema-to-typescript": "^10.1.4",
     "memfs": "^3.2.2",
-    "prettier": "^2.3.0",
+    "prettier": "2.4.1",
     "prettier-plugin-organize-imports": "^2.3.3",
     "release-it": "^14.6.2",
     "ts-jest": "^27.0.3",

--- a/cli/src/mdastToRst.test.ts
+++ b/cli/src/mdastToRst.test.ts
@@ -40,12 +40,16 @@ This is a codeblock.
    :depth: 2
    :class: singlecol
 
+
+
 This is a heading
 ^^^^^^^^^^^^^^^^^
 
 Here is some *text* with an \`external link <https://example.com>\`__ and an :ref:\`anchor link <anchorLink>\`.
 
 .. _anchorLink:
+
+
 
 
 
@@ -61,6 +65,8 @@ Anchored subheading
 .. code-block:: java
 
    This is a codeblock.
+
+
 
 Tables
 ======

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -201,10 +201,6 @@ const visitors: {
     c.add(children, (text) => text.replace(/\*/g, "\\*"));
     c.add("*");
   },
-  group(c, { children }) {
-    c.add(children);
-    c.addNewline();
-  },
   heading(c, { children, depth }) {
     let characterCount = 0;
     c.addDoubleNewline();

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -240,7 +240,7 @@ const visitors: {
     }
     if (value.indexOf("\n") === -1) {
       // Normal case: single inline code
-      c.add(`\`\`${value}\`\``);
+      c.add(` \`\`${value}\`\` `);
       return;
     }
 

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -240,7 +240,7 @@ const visitors: {
     }
     if (value.indexOf("\n") === -1) {
       // Normal case: single inline code
-      c.add(` \`\`${value}\`\` `);
+      c.add(`\`\`${value}\`\` `);
       return;
     }
 

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -203,6 +203,7 @@ const visitors: {
   },
   heading(c, { children, depth }) {
     let characterCount = 0;
+    c.addDoubleNewline();
     c.add(children, (text) => {
       // Spread the text into an array to get actual character count, including
       // wider characters
@@ -271,7 +272,7 @@ const visitors: {
     // TODO
   },
   list(c, n) {
-    c.addNewline();
+    c.addDoubleNewline();
     const firstItemToken = n.ordered ? `${n.start ?? 1}. ` : "- ";
     const itemToken = n.ordered ? "#. " : "- ";
     // Add each child as a list item
@@ -289,7 +290,7 @@ const visitors: {
       c.indented(listItem.children);
       c.addNewline();
     });
-    c.addNewline();
+    c.addDoubleNewline();
   },
   listItem(_, n) {
     console.error(

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -201,6 +201,10 @@ const visitors: {
     c.add(children, (text) => text.replace(/\*/g, "\\*"));
     c.add("*");
   },
+  group(c, { children }) {
+    c.add(children);
+    c.addNewline();
+  },
   heading(c, { children, depth }) {
     let characterCount = 0;
     c.addDoubleNewline();

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -228,9 +228,9 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
               md.paragraph(),
               md.paragraph(
                 [
-                  args.inheritedMethods[interfaceType.qualifiedTypeName].map(
-                    (method, index) => {
-                      return md.group([
+                  args.inheritedMethods[interfaceType.qualifiedTypeName]
+                    .map((method, index) => {
+                      return [
                         md.inlineCode(method),
                         // separate method names with commas, while avoiding trailing comma
                         index <
@@ -239,9 +239,9 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
                           1
                           ? md.text(", ")
                           : md.text(""),
-                      ]);
-                    }
-                  ),
+                      ];
+                    })
+                    .flat(1),
                 ].flat(1)
               ),
             ]),

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -226,13 +226,24 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
               args.project.linkToEntity(interfaceType.qualifiedTypeName),
               md.text(": "),
               md.paragraph(),
-              md.paragraph([
-                md.text(
-                  args.inheritedMethods[interfaceType.qualifiedTypeName].join(
-                    ", "
-                  )
-                ),
-              ]),
+              md.paragraph(
+                [
+                  args.inheritedMethods[interfaceType.qualifiedTypeName].map(
+                    (method, index) => {
+                      return md.root([
+                        md.inlineCode(method),
+                        // separate method names with commas, while avoiding trailing comma
+                        index <
+                        args.inheritedMethods[interfaceType.qualifiedTypeName]
+                          .length -
+                          1
+                          ? md.text(", ")
+                          : md.text(""),
+                      ]);
+                    }
+                  ),
+                ].flat(1)
+              ),
             ]),
           ];
         })
@@ -300,9 +311,7 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
 
     // package
     md.paragraph([
-      md.emphasis(md.text("Package")),
-      md.text(" "),
-      md.inlineCode(doc.containingPackage.name),
+      md.emphasis(md.text(`Package ${doc.containingPackage.name}`)),
     ]),
 
     // Class hierarchy

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -123,15 +123,15 @@ async function processJson(
 }
 
 function getTitle(doc: ParsedClassDoc): string {
-  let type = ""
+  let type = "";
   if (doc.isInterface) {
-    type = "Interface "
+    type = "Interface ";
   } else if (doc.isClass) {
-    type = "Class "
+    type = "Class ";
   } else if (doc.isEnum) {
-    type = "Enum "
+    type = "Enum ";
   } else if (doc.isException) {
-    type = "Exception "
+    type = "Exception ";
   }
   return `${type}${doc.name}`;
 }

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -230,7 +230,7 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
                 [
                   args.inheritedMethods[interfaceType.qualifiedTypeName].map(
                     (method, index) => {
-                      return md.root([
+                      return md.paragraph([
                         md.inlineCode(method),
                         // separate method names with commas, while avoiding trailing comma
                         index <

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -230,7 +230,7 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
                 [
                   args.inheritedMethods[interfaceType.qualifiedTypeName].map(
                     (method, index) => {
-                      return md.paragraph([
+                      return md.group([
                         md.inlineCode(method),
                         // separate method names with commas, while avoiding trailing comma
                         index <

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -123,17 +123,17 @@ async function processJson(
 }
 
 function getTitle(doc: ParsedClassDoc): string {
-  var type = ""
+  let type = ""
   if (doc.isInterface) {
-    type = "Interface"
+    type = "Interface "
   } else if (doc.isClass) {
-    type = "Class"
+    type = "Class "
   } else if (doc.isEnum) {
-    type = "Enum"
+    type = "Enum "
   } else if (doc.isException) {
-    type = "Exception"
+    type = "Exception "
   }
-  return type + " " + doc.name
+  return `${type}${doc.name}`;
 }
 
 async function processClassDoc(
@@ -218,9 +218,7 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
           md.listItem(
             [
               md.text(args.prefix), args.project.linkToEntity(interfaceType.qualifiedTypeName), md.text(": "), md.paragraph(),
-              md.paragraph([args.inheritedMethods[interfaceType.qualifiedTypeName].map(
-                (method, index) => { return md.root([md.inlineCode(method + "()"), (index < args.inheritedMethods[interfaceType.qualifiedTypeName].length - 1 ? md.text(", ") : md.text(""))])}
-              )].flat(1))
+              md.paragraph([md.text(args.inheritedMethods[interfaceType.qualifiedTypeName].join(", "))])
             ]
           )
         ]

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -8,7 +8,12 @@ import { Page } from "../../Page.js";
 import { Project } from "../../Project.js";
 import { Node } from "../../yokedast.js";
 import { buildIndexes, packageToFolderPath } from "./buildIndexes.js";
-import { MethodDoc, ParsedClassDoc, ParsedPackageDoc, Type } from "./doclet8.js";
+import {
+  MethodDoc,
+  ParsedClassDoc,
+  ParsedPackageDoc,
+  Type,
+} from "./doclet8.js";
 import { execJavadoc, ExecJavadocResult } from "./execJavadoc.js";
 import { tagsToMdast } from "./tagsToYokedast.js";
 
@@ -213,17 +218,27 @@ function makeInheritedMethodList(args: MakeInheritedMethodListArgs) {
   return [
     md.list(
       "unordered",
-      args.list.map((interfaceType) => {
-        return [
-          md.listItem(
-            [
-              md.text(args.prefix), args.project.linkToEntity(interfaceType.qualifiedTypeName), md.text(": "), md.paragraph(),
-              md.paragraph([md.text(args.inheritedMethods[interfaceType.qualifiedTypeName].join(", "))])
-            ]
-          )
-        ]
-      }).flat(1))
-  ]
+      args.list
+        .map((interfaceType) => {
+          return [
+            md.listItem([
+              md.text(args.prefix),
+              args.project.linkToEntity(interfaceType.qualifiedTypeName),
+              md.text(": "),
+              md.paragraph(),
+              md.paragraph([
+                md.text(
+                  args.inheritedMethods[interfaceType.qualifiedTypeName].join(
+                    ", "
+                  )
+                ),
+              ]),
+            ]),
+          ];
+        })
+        .flat(1)
+    ),
+  ];
 }
 
 function makeImplementedInterfacesList(project: Project, doc: ParsedClassDoc) {
@@ -284,7 +299,11 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
     }),
 
     // package
-    md.paragraph([md.emphasis(md.text("Package")), md.text(" "), md.inlineCode(doc.containingPackage.name)]),
+    md.paragraph([
+      md.emphasis(md.text("Package")),
+      md.text(" "),
+      md.inlineCode(doc.containingPackage.name),
+    ]),
 
     // Class hierarchy
     ...makeSuperclassList(project, doc),
@@ -400,15 +419,15 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
           doc,
           list: doc.superclasses,
           inheritedMethods: doc.inheritedMethods,
-          prefix: "Methods inherited from interface "
+          prefix: "Methods inherited from interface ",
         }),
-        ...makeInheritedMethodList({
-          project,
-          doc,
-          list: doc.interfaceTypes,
-          inheritedMethods: doc.inheritedMethods,
-          prefix: "Methods inherited from class "
-        })
+      ...makeInheritedMethodList({
+        project,
+        doc,
+        list: doc.interfaceTypes,
+        inheritedMethods: doc.inheritedMethods,
+        prefix: "Methods inherited from class ",
+      }),
     }),
 
     ...makeSection({


### PR DESCRIPTION
Example: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/testytesttest/io/realm/DynamicRealm/Callback/

- cleaned up some section titles that bled into each other
- removed package from title (could sometimes be too long), replaced with enum/class/exception/interface
- added package declaration *beneath* title (consistent with javadoc)
- changed inherited method summary from bulleted list of methods for each inherited class/interface to a comma separated list
- removed links on each inherited method, replaced with single link on inherited class/interface item