### PR TITLE
various fixes

### DIFF
--- a/cli/src/mdastToRst.test.ts
+++ b/cli/src/mdastToRst.test.ts
@@ -45,7 +45,7 @@ This is a codeblock.
 This is a heading
 ^^^^^^^^^^^^^^^^^
 
-Here is some *text* with an \`external link <https://example.com>\`__ and an :ref:\`anchor link <anchorLink>\`.
+Here is some *text* with an \`external link <https://example.com>\`__  and an :ref:\`anchor link <anchorLink>\`.
 
 .. _anchorLink:
 

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -238,6 +238,11 @@ const visitors: {
     if (value === undefined) {
       return;
     }
+    if (value.endsWith(" - ")) {
+      // rst does not like the "- ``" character sequence. Don't ask me why.
+      c.add(`\`\`${value.slice(0, -3)}\`\`: `);
+      return;
+    }
     if (value.indexOf("\n") === -1) {
       // Normal case: single inline code
       c.add(`\`\`${value}\`\` `);
@@ -248,7 +253,11 @@ const visitors: {
     c.indented(value);
   },
   link(c, n) {
-    const escaper = (text: string) => text.replace(/([<`])/g, "\\$1");
+    const escaper = (text: string) =>
+      text
+        .replace(/([<`])/g, "\\$1")
+        .replace(/^#/, "") // octothorpe at beginning of ref name: remove
+        .replace(/#/, "."); // octothorpe in the middle of ref name: turn into the dot it ought to be;
     const { url } = n;
     const isRefLink = !/^https?:\/\//.test(url);
     if (isRefLink) {
@@ -265,7 +274,7 @@ const visitors: {
       c.add(` <${anchorName}>\``);
     } else {
       c.add(` <${url}>`);
-      c.add("`__");
+      c.add("`__ ");
     }
   },
   linkToEntity() {
@@ -309,6 +318,12 @@ const visitors: {
   separator(c) {
     // https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#transitions
     c.add("----");
+    c.addDoubleNewline();
+  },
+  seealso(c, n) {
+    c.add(".. seealso::");
+    c.addNewline();
+    c.indented(n.children);
     c.addDoubleNewline();
   },
   strike() {

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -238,19 +238,11 @@ const visitors: {
     if (value === undefined) {
       return;
     }
-    if (value.endsWith(" - ")) {
-      // rst does not like the "- ``" character sequence. Don't ask me why.
-      c.add(`\`\`${value.slice(0, -3)}\`\`: `);
-      return;
-    }
     if (value.indexOf("\n") === -1) {
       // Normal case: single inline code
-      c.add(`\`\`${value}\`\` `);
+      c.add(`\`\`${value.trim()}\`\` `);
       return;
     }
-
-    // Weird case (for javadoc)
-    c.indented(value);
   },
   link(c, n) {
     const escaper = (text: string) =>

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -64,7 +64,7 @@ function getType(doc: ParsedClassDoc): EntityType {
 }
 
 function capitalize(str: string): string {
-  if (str == null || str.length < 1) {
+  if (str.length < 1) {
     return "";
   } else {
     return str[0].toUpperCase() + str.slice(1);
@@ -207,7 +207,7 @@ function makeTable(labels: string[], rows: (Node | Node[])[][]) {
   );
 }
 
-function makeSeeAlso(project: Project, tags: SeeTag[], depth: number) {
+function makeSeeAlso(project: Project, tags: SeeTag[]) {
   if (tags.length == 0) {
     return [];
   }
@@ -352,7 +352,7 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
     tagsToMdast(project, doc.inlineTags),
 
     // See Also
-    ...makeSeeAlso(project, doc.seeTags, depth),
+    ...makeSeeAlso(project, doc.seeTags),
 
     ...makeSection({
       ...args,
@@ -636,8 +636,11 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
               "unordered",
               doc.typeParamTags.map((tag) => {
                 return md.listItem([
-                  md.inlineCode(`${tag.parameterName} - `),
-                  tagsToMdast(project, tag.inlineTags ?? []),
+                  md.paragraph([
+                    md.inlineCode(`${tag.parameterName}`),
+                    md.text("- "),
+                    tagsToMdast(project, tag.inlineTags ?? []),
+                  ]),
                 ]);
               })
             );
@@ -655,8 +658,11 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
               "unordered",
               doc.paramTags.map((paramTag) => {
                 return md.listItem([
-                  md.inlineCode(`${paramTag.parameterName} - `),
-                  tagsToMdast(project, paramTag.inlineTags ?? []),
+                  md.paragraph([
+                    md.inlineCode(`${paramTag.parameterName}`),
+                    md.text("- "),
+                    tagsToMdast(project, paramTag.inlineTags ?? []),
+                  ]),
                 ]);
               })
             );
@@ -709,7 +715,7 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
         }),
 
         // "See also" section
-        ...makeSeeAlso(project, doc.seeTags, depth + 2),
+        ...makeSeeAlso(project, doc.seeTags),
       ];
     })
     .flat(1);

--- a/cli/src/yokedast.ts
+++ b/cli/src/yokedast.ts
@@ -35,6 +35,10 @@ export type EntityAnchorNode<UserDataType = unknown> = ReturnType<
   entity: Entity<UserDataType>;
 };
 
+export type SeeAlsoNode = Parent & {
+  type: "seealso";
+};
+
 export type ToctreeNode = Parent & {
   type: "toctree";
 };
@@ -63,6 +67,13 @@ export const toctreeItem = ({
   };
 };
 
+export const seealso = (children: Node[]): SeeAlsoNode => {
+  return {
+    children,
+    type: "seealso",
+  };
+};
+
 export type RootNode = ReturnType<typeof MdastBuilder.root>;
 
 export type CodeNode = ReturnType<typeof MdastBuilder.code>;
@@ -86,6 +97,7 @@ type YokedastNodes = {
   linkToEntity: () => LinkToEntityNode;
   toctree: typeof toctree;
   toctreeItem: typeof toctreeItem;
+  seealso: typeof seealso;
 };
 
 export type MdastNodeType = keyof MdastNodes;


### PR DESCRIPTION
- fixed broken monospace parameters in method detail containing "- ``" sequence
- removed nasty ugly octothorpes in URL names throughout refs
- fixed refs broken by alphanumeric characters appearing RIGHT after the ref (no space)
- added seealso directive
- used seealso directive for "see also" content in global page descriptions & method detail seealsos
- turned package into a header to make it more visible
- removed "superclasses" label on superclass list to better match the javadoc style, simplify page

For an example of the changes in action: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/testytesttest/io/realm/mongodb/sync/SyncSession/