### PR TITLE
Method detail -- instances improvements

### DIFF
--- a/cli/src/mdastToRst.test.ts
+++ b/cli/src/mdastToRst.test.ts
@@ -45,7 +45,7 @@ This is a codeblock.
 This is a heading
 ^^^^^^^^^^^^^^^^^
 
-Here is some *text* with an \`external link <https://example.com>\`__  and an :ref:\`anchor link <anchorLink>\`.
+Here is some *text* with an \`external link <https://example.com>\`__  and an :ref:\`anchor link <anchorLink>\` .
 
 .. _anchorLink:
 

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -190,7 +190,7 @@ const visitors: {
 
     c.addDoubleNewline();
     c.add(`.. code-block:: ${lang}\n`);
-    c.indented(`\n${value}`);
+    c.indented(`\n${value.replace(/\\@/, "@")}`);
     c.addDoubleNewline();
   },
   entityAnchor() {

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -201,6 +201,12 @@ const visitors: {
     c.add(children, (text) => text.replace(/\*/g, "\\*"));
     c.add("*");
   },
+  example(c, n) {
+    c.add(`.. example:: `);
+    c.addDoubleNewline();
+    c.indented(n.children);
+    c.addDoubleNewline();
+  },
   heading(c, { children, depth }) {
     let characterCount = 0;
     c.addDoubleNewline();
@@ -314,7 +320,7 @@ const visitors: {
   },
   seealso(c, n) {
     c.add(".. seealso::");
-    c.addNewline();
+    c.addDoubleNewline();
     c.indented(n.children);
     c.addDoubleNewline();
   },

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -319,6 +319,7 @@ const visitors: {
     c.addDoubleNewline();
   },
   seealso(c, n) {
+    c.addDoubleNewline();
     c.add(".. seealso::");
     c.addDoubleNewline();
     c.indented(n.children);

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -269,7 +269,7 @@ const visitors: {
         anchorName !== undefined,
         `unexpected refLink without anchorName from url: ${url}`
       );
-      c.add(` <${anchorName}>\``);
+      c.add(` <${anchorName}>\` `);
     } else {
       c.add(` <${url}>`);
       c.add("`__ ");

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -190,7 +190,7 @@ const visitors: {
 
     c.addDoubleNewline();
     c.add(`.. code-block:: ${lang}\n`);
-    c.indented(`\n${value.replace(/\\@/, "@")}`);
+    c.indented(`\n${value.replace(/\\@/g, "@")}`);
     c.addDoubleNewline();
   },
   entityAnchor() {

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -9,6 +9,7 @@ import { Project } from "../../Project.js";
 import { Node, seealso } from "../../yokedast.js";
 import { buildIndexes, packageToFolderPath } from "./buildIndexes.js";
 import {
+  AnyType,
   MethodDoc,
   ParsedClassDoc,
   ParsedPackageDoc,
@@ -150,6 +151,27 @@ async function processJson(
     }
   });
   await Promise.all(promises);
+}
+
+function processParam(param: AnyType): string {
+  if (param.simpleTypeName.includes("Class")) {
+    return "Class";
+  } else if (param.simpleTypeName.includes("ImportFlag")) {
+    return "ImportFlag...";
+  } else if (param.simpleTypeName.includes("Iterable")) {
+    return "Iterable";
+  } else if (
+    param.simpleTypeName ===
+    "E" /*&& TODO: Figure out how to filter for E implements RealmModel a bit... better
+    (param.bounds as AnyDoc[]).filter(
+      (doc) => doc.simpleTypeName != "RealmModel"
+    ).length > 1*/
+  ) {
+    return "RealmModel";
+  } else if (param.simpleTypeName == "Callback") {
+    return "App.Callback";
+  }
+  return param.simpleTypeName;
 }
 
 function getTitle(doc: ParsedClassDoc): string {
@@ -646,6 +668,12 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
           canonicalName: `${doc.qualifiedName}(${doc.parameters
             .map((param) => param.type.simpleTypeName)
             .join(",")})`,
+          pageUri,
+        }),
+        project.declareEntity({
+          canonicalName: `${doc.qualifiedName}(${doc.parameters
+            .map((param) => processParam(param.type))
+            .join(", ")})`,
           pageUri,
         }),
 

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -161,15 +161,17 @@ function processParam(param: AnyType): string {
   } else if (param.simpleTypeName.includes("Iterable")) {
     return "Iterable";
   } else if (
-    param.simpleTypeName ===
-    "E" /*&& TODO: Figure out how to filter for E implements RealmModel a bit... better
-    (param.bounds as AnyDoc[]).filter(
-      (doc) => doc.simpleTypeName != "RealmModel"
-    ).length > 1*/
+    param.simpleTypeName === "E" // TODO: Figure out how to filter for E implements RealmModel a bit... better
   ) {
     return "RealmModel";
   } else if (param.simpleTypeName == "Callback") {
     return "App.Callback";
+  } else if (param.qualifiedTypeName == "org.json.JSONObject") {
+    return "org.json.JSONObject";
+  } else if (param.qualifiedTypeName == "java.io.InputStream") {
+    return "java.io.InputStream";
+  } else if (param.qualifiedTypeName == "org.json.JSONArray") {
+    return "org.json.JSONArray";
   }
   return param.simpleTypeName;
 }
@@ -655,7 +657,7 @@ const makeMethodDetailBody: MakeBodyFunction = (args) => {
 };
 
 const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
-  const { project, pageUri, depth, doc: overloadDocs } = args;
+  const { project, pageUri, doc: overloadDocs } = args;
   return overloadDocs
     .map((doc) => {
       const canonicalName = getCanonicalNameForMethod(doc);

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -544,7 +544,7 @@ const makeParameterListWithLinks = (
   doc: MethodDoc
 ): Node[] => {
   return [
-    md.text("("),
+    doc.parameters.length > 1 ? md.text("(\n |\t\t") : md.text("("),
     ...doc.parameters
       .map((parameter, i) => [
         project.linkToEntity(
@@ -552,7 +552,9 @@ const makeParameterListWithLinks = (
           parameter.typeName
         ),
         md.text(
-          ` ${parameter.name ?? ""}${i < doc.parameters.length - 1 ? ", " : ""}`
+          ` ${parameter.name ?? ""}${
+            i < doc.parameters.length - 1 ? ",\n" + " |\t\t" : ""
+          }`
         ),
       ])
       .flat(1),
@@ -647,6 +649,7 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
           [
             tagsToMdast(project, doc.inlineTags),
 
+            md.paragraph(),
             // Type Parameters section
             doc.typeParamTags.length !== 0
               ? md.paragraph([

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -400,7 +400,7 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
           ["Modifier and Type", "Field and Description"],
           doc.fields.map((fieldDoc) => [
             md.paragraph([
-              md.inlineCode(fieldDoc.modifiers + fieldDoc.type.asString),
+              md.inlineCode(`${fieldDoc.modifiers} ${fieldDoc.type.asString}`),
             ]),
             [
               md.paragraph(md.inlineCode(fieldDoc.name)),
@@ -505,6 +505,10 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
           .map((doc) => [
             project.declareEntity({
               canonicalName: doc.qualifiedName,
+              pageUri,
+            }),
+            project.declareEntity({
+              canonicalName: `${doc.containingClass?.typeName}.${doc.name}`,
               pageUri,
             }),
             md.heading(3, md.inlineCode(doc.name)),
@@ -617,6 +621,12 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
       return [
         project.declareEntity({
           canonicalName,
+          pageUri,
+        }),
+        project.declareEntity({
+          canonicalName: `${doc.qualifiedName}(${doc.parameters
+            .map((param) => param.type.simpleTypeName)
+            .join(",")})`,
           pageUri,
         }),
 

--- a/cli/src/plugins/javadoc/tagsToYokedast.ts
+++ b/cli/src/plugins/javadoc/tagsToYokedast.ts
@@ -111,8 +111,8 @@ const visitor: TagVisitor<Project, Node | Node[]> = {
     }
   },
   SeeTag(tag, project) {
-    if (tag.kind === "Text") {
-      return md.text(tag.text);
+    if (tag.text.includes("<a href=")) {
+      return parseHtmlToMdast(tag.text);
     }
     return project.linkToEntity(
       [tag.referencedClassName, tag.referencedMemberName]
@@ -120,7 +120,7 @@ const visitor: TagVisitor<Project, Node | Node[]> = {
         .join("."),
       tag.text
         .replace(/^#/, "") // octothorpe at beginning of ref name: remove
-        .replace(/#/, ".") // octothorpe in the middle of ref name: turn into the dot it ought to be;
+        .replace(/#/g, ".") // octothorpe in the middle of ref name: turn into the dot it ought to be;
     );
   },
 };

--- a/cli/src/yokedast.ts
+++ b/cli/src/yokedast.ts
@@ -35,6 +35,10 @@ export type EntityAnchorNode<UserDataType = unknown> = ReturnType<
   entity: Entity<UserDataType>;
 };
 
+export type ExampleNode = Parent & {
+  type: "example";
+};
+
 export type SeeAlsoNode = Parent & {
   type: "seealso";
 };
@@ -74,6 +78,13 @@ export const seealso = (children: Node[]): SeeAlsoNode => {
   };
 };
 
+export const example = (children: Node[]): ExampleNode => {
+  return {
+    children,
+    type: "example",
+  };
+};
+
 export type RootNode = ReturnType<typeof MdastBuilder.root>;
 
 export type CodeNode = ReturnType<typeof MdastBuilder.code>;
@@ -98,6 +109,7 @@ type YokedastNodes = {
   toctree: typeof toctree;
   toctreeItem: typeof toctreeItem;
   seealso: typeof seealso;
+  example: typeof example;
 };
 
 export type MdastNodeType = keyof MdastNodes;


### PR DESCRIPTION
Example: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/testytestytesttest/io/realm/Realm/

Javadoc for comprison: https://docs.mongodb.com/realm-sdks/java/latest/

Ended up going with tables for organization -- see the old approach (example blocks) here:
Example: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/testytesttest/io/realm/Realm/

Leaving in the example directive implementation because... well, it works.

Also fixed annotation examples containing a "\\@" instead of a "@".

Also fixed a whole lot of wonky refs that weren't lining up before. This means adding a lot of subtle variations on anchor links, which is... OK, I guess.