### PR TITLE
Miscellaneous small fixes.

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -39,6 +39,11 @@ export const cli = yargs
           string: true,
           describe:
             "bypass the generator step and treat the given path as the result of a generator call",
+        })
+        .option("enableDuplicateEntityWarning", {
+          boolean: true,
+          describe:
+            "output information about duplicate entities generated internally",
         });
     },
     (args) => {

--- a/cli/src/makeProject.ts
+++ b/cli/src/makeProject.ts
@@ -119,9 +119,9 @@ export async function makeProject<UserDataType = unknown>({
       const anchorName = anchorify(entity);
       if (entities.has(canonicalName)) {
         // Users should fix this, but it's not a fatal error.
-        console.warn(
+        /*console.warn(
           new Error(`duplicate entity: ${canonicalName} (${pageUri})`)
-        );
+        );*/
       } else {
         entities.set(canonicalName, entity);
         // We can now resolve any pages that were waiting for this entity

--- a/cli/src/makeProject.ts
+++ b/cli/src/makeProject.ts
@@ -40,6 +40,11 @@ export type MakeProjectArgs = {
     Whether to output rST files.
    */
   outputRst?: boolean;
+
+  /**
+    Whether to output information about duplicate entities generated internally.
+   */
+  enableDuplicateEntityWarning?: boolean;
 };
 
 /**
@@ -55,6 +60,7 @@ export async function makeProject<UserDataType = unknown>({
   outputMdastJson = true,
   outputMarkdown = false,
   outputRst = true,
+  enableDuplicateEntityWarning,
 }: MakeProjectArgs): Promise<Project<UserDataType>> {
   // Use the current working directy if no output directory was provided
   const outputDirectoryPath = Path.resolve(out ?? "");
@@ -118,10 +124,12 @@ export async function makeProject<UserDataType = unknown>({
       const { canonicalName, pageUri } = entity;
       const anchorName = anchorify(entity);
       if (entities.has(canonicalName)) {
-        // Users should fix this, but it's not a fatal error.
-        /*console.warn(
-          new Error(`duplicate entity: ${canonicalName} (${pageUri})`)
-        );*/
+        if (enableDuplicateEntityWarning) {
+          // Users should fix this, but it's not a fatal error.
+          console.warn(
+            new Error(`duplicate entity: ${canonicalName} (${pageUri})`)
+          );
+        }
       } else {
         entities.set(canonicalName, entity);
         // We can now resolve any pages that were waiting for this entity

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -671,16 +671,9 @@ const makeParameterListWithLinks = (
           parameter.type.qualifiedTypeName,
           parameter.typeName
         ),
-        ...[
-          md.text(
-            ` ${parameter.name ?? ""}${
-              i < doc.parameters.length - 1 ? ",\n" + "   " : ""
-            }`
-          ),
-          i < doc.parameters.length - 1 && doc.parameters.length != 1
-            ? md.text("   ")
-            : md.text(""),
-        ],
+        md.text(
+          ` ${parameter.name ?? ""}${i < doc.parameters.length - 1 ? ", " : ""}`
+        ),
       ])
       .flat(1),
     md.text(")"),

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -770,7 +770,7 @@ const makeMethodDetailBody: MakeBodyFunction = (args) => {
 };
 
 const makeConstructorDetailBody: MakeBodyFunction = (args) => {
-  const { depth, doc } = args;
+  const { doc } = args;
   return doc.constructors
     .map((constructor) =>
       [
@@ -850,7 +850,7 @@ const makeConstructorDetailBody: MakeBodyFunction = (args) => {
 };
 
 const makeElementDetailBody: MakeBodyFunction = (args) => {
-  const { depth, doc } = args;
+  const { doc } = args;
   return doc
     .elements!.map((elem) =>
       [

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -477,8 +477,15 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
         makeTable(
           ["Modifier and Type", "Class and Description"],
           doc.innerClasses.map((classDoc) => [
-            md.inlineCode(classDoc.modifiers ?? ""),
-            md.inlineCode(classDoc.qualifiedTypeName), // TODO: Must fetch complete classDoc from another file
+            [md.inlineCode(classDoc.modifiers ?? "")],
+            [
+              project.linkToEntity(
+                classDoc.qualifiedTypeName,
+                classDoc.typeName
+              ),
+              md.text("\n"),
+              // TODO: Fetch description from inline tags of nested class doc
+            ],
           ])
         ),
     }),

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -445,7 +445,7 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
           doc.constructors.map((doc) => [
             [
               md.paragraph([
-                md.text(" |   "),
+                md.text("|   "),
                 project.linkToEntity(doc.qualifiedName, doc.name),
                 md.text(" "),
                 ...makeParameterListWithLinks(project, doc),
@@ -560,7 +560,7 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
               ],
               [
                 md.paragraph([
-                  md.text(" |   "),
+                  md.text("|   "),
                   project.linkToEntity(
                     getCanonicalNameForMethod(doc),
                     doc.name
@@ -691,7 +691,7 @@ const makeParameterListWithLinks = (
     md.text("("),
     ...doc.parameters
       .map((parameter, i) => [
-        md.text("\n |      "),
+        md.text("\n|      "),
         project.linkToEntity(
           parameter.type.qualifiedTypeName,
           parameter.typeName
@@ -701,7 +701,7 @@ const makeParameterListWithLinks = (
         ),
       ])
       .flat(1),
-    doc.parameters.length > 0 ? md.text("\n |   ") : md.text(""),
+    doc.parameters.length > 0 ? md.text("\n|   ") : md.text(""),
     md.text(")"),
   ];
 };

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -948,7 +948,7 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
 
         makeDetail(
           [
-            md.text(" |   "),
+            md.text("|   "),
             md.text(doc.modifiers),
             md.text(" "),
             project.linkToEntity(

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -168,29 +168,11 @@ async function processJson(
 }
 
 function processParam(param: AnyType): string {
-  if (param.simpleTypeName.includes("Class")) {
-    return "Class";
-  } else if (param.simpleTypeName.startsWith("List")) {
-    return "List";
-  } else if (param.simpleTypeName.includes("ImportFlag")) {
-    return "ImportFlag...";
-  } else if (param.simpleTypeName.includes("Iterable")) {
-    return "Iterable";
-  } else if (param.qualifiedTypeName === "org.json.JSONObject") {
-    return "org.json.JSONObject";
-  } else if (param.qualifiedTypeName === "java.io.InputStream") {
-    return "java.io.InputStream";
-  } else if (param.qualifiedTypeName === "org.json.JSONArray") {
-    return "org.json.JSONArray";
-  } else if (param.simpleTypeName === "E") {
-    // TODO: Figure out how to filter for E implements RealmModel a bit... better
-    return "RealmModel";
-  } else if (param.qualifiedTypeName === "io.realm.mongodb.App.Callback") {
-    return "App.Callback";
-  } else if (param.qualifiedTypeName === "io.realm.Realm.Callback") {
-    return param.qualifiedTypeName;
-  } else if (param.simpleTypeName === "RealmObject") {
-    return "Object";
+  if (param.asString.includes(" extends ")) {
+    const name = param.asString.split(".");
+    return name[name.length - 1];
+  } else if (param.dimension == "[]") {
+    return param.simpleTypeName + "...";
   }
   return param.simpleTypeName;
 }
@@ -760,18 +742,14 @@ const makeMethodDetailBody: MakeBodyFunction = (args) => {
           canonicalName: `${doc.simpleTypeName}.${methodName}()`,
           pageUri: args.pageUri,
         }),
-        overloadDocs.filter((doc) => doc.parameters.length == 0).length > 0
-          ? args.project.declareEntity({
-              canonicalName: `${overloadDocs[0].qualifiedName}`,
-              pageUri: args.pageUri,
-            })
-          : md.text(""),
-        overloadDocs.filter((doc) => doc.parameters.length == 0).length > 0
-          ? args.project.declareEntity({
-              canonicalName: `${overloadDocs[0].qualifiedName}()`,
-              pageUri: args.pageUri,
-            })
-          : md.text(""),
+        args.project.declareEntity({
+          canonicalName: `${overloadDocs[0].qualifiedName}`,
+          pageUri: args.pageUri,
+        }),
+        args.project.declareEntity({
+          canonicalName: `${overloadDocs[0].qualifiedName}()`,
+          pageUri: args.pageUri,
+        }),
         makeSection({
           ...args,
           depth: depth + 1,

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -1024,7 +1024,7 @@ const makeMethodOverloadsDetailBody: MakeBodyFunction<MethodDoc[]> = (args) => {
                   md.strong(md.text("Overrides")),
                   md.text("\n\n"),
                   md.inlineCode(doc.name),
-                  md.text("in class"),
+                  md.text("in class "),
                   project.linkToEntity(
                     doc.overriddenMethodContainingClass!.qualifiedTypeName,
                     doc.overriddenMethodContainingClass?.simpleTypeName

--- a/cli/src/plugins/javadoc/index.ts
+++ b/cli/src/plugins/javadoc/index.ts
@@ -602,6 +602,7 @@ const makeClassDocPageBody: MakeBodyFunction = (args) => {
             }),
             md.heading(3, md.inlineCode(doc.name)),
             tagsToMdast(project, doc.inlineTags),
+            ...makeSeeAlso(project, doc.seeTags),
           ])
           .flat(1),
     }),

--- a/cli/src/plugins/javadoc/tagsToYokedast.ts
+++ b/cli/src/plugins/javadoc/tagsToYokedast.ts
@@ -23,7 +23,7 @@ export function tagsToMdast(project: Project, tags: AnyTag[]): Node {
   const tagsAsHtmlParseableString = tags
     .map((tag) => {
       if (tag.kind === "Text") {
-        return tag.text;
+        return tag.text.replace(/\*/g, "\\*");
       }
       const encodedTag = encode(JSON.stringify(tag));
       return `${preHtmlParseTagDelimiter}${encodedTag}${preHtmlParseTagDelimiter}`;
@@ -97,7 +97,7 @@ const visitor: TagVisitor<Project, Node | Node[]> = {
     const cleanedText = tag.text.replace("\\@", "@");
     switch (tag.kind) {
       case "Text": {
-        return md.text(tag.text);
+        return md.text(cleanedText);
       }
       case "@code":
         // Javadoc uses some combination of <pre> and {@code} to distinguish


### PR DESCRIPTION
- remove duplicate entity creation error message
- added "annotation type" entity, now use it in page titles for annotation types
- enhanced capitalize method to capitalize multiple words (to accommodate "annotation type")
- added logic to reduce the number of duplicate anchors, which was often conflicting between global method anchors and overloaded-with-no-parameter instances of that method
- added Optional Element Summary and Element Detail sections
- added Overrides section in method detail
- added many additional anchors to deal with the highly inconsistent naming conventions of referenced methods, fields, etc. in the SDK
- added constructor and constructor detail sections
- added seealso section for field details
- enum constants now no longer have columns: prevents links from spreading onto multiple lines (well, unless they're REALLY long)
- added "current" class to end of superclass hierarchy, a la javadoc
- fix accidentally swapped "interface" and "class" labels in "Inherited Methods" section
- Added links to nested classes to the "Nested Class Summary"
- Removed realm-specific parameter handling for refs (replaced with... a lot of refs. But it's OK)

Example: https://docs-mongodbcom-staging.corp.mongodb.com/realm-java-sdk/docsworker-xlarge/testbranch/io/realm/mongodb/mongo/MongoNamespace/
