### PR TITLE
Fix @ escape and block-quote

### DIFF
--- a/cli/src/mdastToRst.test.ts
+++ b/cli/src/mdastToRst.test.ts
@@ -13,6 +13,8 @@ Here is some *text* with an [external link](https://example.com) and an [anchor 
 
 ## Anchored subheading
 
+This at-symbol will turn into a mailto link if not escaped: @LinkingObjects
+
 >It's a **blockquote.**
 
 \`\`\`java
@@ -56,6 +58,11 @@ Here is some *text* with an \`external link <https://example.com>\`__  and an :r
 Anchored subheading
 ===================
 
+This at-symbol will turn into a mailto link if not escaped: \\@LinkingObjects
+
+
+
+.. block-quote::
 
    It's a **blockquote.**
    

--- a/cli/src/mdastToRst.ts
+++ b/cli/src/mdastToRst.ts
@@ -174,6 +174,9 @@ const visitors: {
 } = {
   blockquote(c, node) {
     // https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#block-quotes
+    // Snooty doesn't support the indent-only blockquote, instead uses a directive.
+    c.addDoubleNewline();
+    c.add(`.. block-quote::\n`);
     c.indented("\n");
     c.indented(node.children);
     c.addNewline();
@@ -366,7 +369,8 @@ const visitors: {
     if (value === undefined) {
       return;
     }
-    c.add(value.replace(/`/g, "\\`"));
+    // @-symbol must be escaped in sphinx or else it creates a mailto: link
+    c.add(value.replace(/`/g, "\\`").replace(/@/g, "\\@"));
   },
   toctree(c, n) {
     c.add(`.. toctree::


### PR DESCRIPTION
- Unescaped @ makes mailto: links in snooty (apparently)
- Indent-only block quote not supported, use directive